### PR TITLE
PostgreSQL and MySQL compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,8 @@
         "php": ">=5.3.3",
         "zendframework/zendframework": "2.2.*",
         "zendframework/zend-developer-tools": "dev-master"
+    },
+    "autoload": {
+        "psr-0": {"Bareos\\": "vendor/Bareos/library/"}
     }
 }

--- a/module/Client/Module.php
+++ b/module/Client/Module.php
@@ -6,6 +6,7 @@ use Client\Model\Client;
 use Client\Model\ClientTable;
 use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\TableGateway\TableGateway;
+use Bareos\Db\Sql\BareosSqlCompatHelper;
 
 class Module
 {
@@ -42,7 +43,9 @@ class Module
 					$dbAdapter = $sm->get('Zend\Db\Adapter\Adapter');
 					$resultSetPrototype = new ResultSet();
 					$resultSetPrototype->setArrayObjectPrototype(new Client());
-					return new TableGateway('client', $dbAdapter, null, $resultSetPrototype);
+					$config = $sm->get('Config');
+					$bsqlch = new BareosSqlCompatHelper($config['db']['driver']);
+					return new TableGateway($bsqlch->strdbcompat("Client"), $dbAdapter, null, $resultSetPrototype);
 				},
 			),
 		);

--- a/module/Client/src/Client/Model/Client.php
+++ b/module/Client/src/Client/Model/Client.php
@@ -14,6 +14,8 @@ class Client
 
 	public function exchangeArray($data)
 	{
+		$data = array_change_key_case($data, CASE_LOWER);
+
 		$this->clientid = (!empty($data['clientid'])) ? $data['clientid'] : null;
 		$this->name = (!empty($data['name'])) ? $data['name'] : null;
 		$this->uname = (!empty($data['uname'])) ? $data['uname'] : null;

--- a/module/File/Module.php
+++ b/module/File/Module.php
@@ -6,6 +6,7 @@ use File\Model\File;
 use File\Model\FileTable;
 use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\TableGateway\TableGateway;
+use Bareos\Db\Sql\BareosSqlCompatHelper;
 
 class Module
 {
@@ -42,7 +43,9 @@ class Module
 					$dbAdapter = $sm->get('Zend\Db\Adapter\Adapter');
 					$resultSetPrototype = new ResultSet();
 					$resultSetPrototype->setArrayObjectPrototype(new File());
-					return new TableGateway('file', $dbAdapter, null, $resultSetPrototype);
+					$config = $sm->get('Config');
+					$bsqlch = new BareosSqlCompatHelper($config['db']['driver']);
+					return new TableGateway($bsqlch->strdbcompat("File"), $dbAdapter, null, $resultSetPrototype);
 				},
 			),
 		);

--- a/module/File/src/File/Model/File.php
+++ b/module/File/src/File/Model/File.php
@@ -1,5 +1,28 @@
 <?php
 
+/**
+ *
+ * bareos-webui - Bareos Web-Frontend
+ * 
+ * @link      https://github.com/bareos/bareos-webui for the canonical source repository
+ * @copyright Copyright (c) 2013-2014 dass-IT GmbH (http://www.dass-it.de/)
+ * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 namespace File\Model;
 
 class File 
@@ -13,6 +36,8 @@ class File
 
 	public function exchangeArray($data)
 	{
+		$data = array_change_key_case($data, CASE_LOWER);		
+
 		$this->fileid = (!empty($data['fileid'])) ? $data['fileid'] : null;
 		$this->jobid = (!empty($data['jobid'])) ? $data['jobid'] : null;
 		$this->pathid = (!empty($data['pathid'])) ? $data['pathid'] : null;

--- a/module/File/src/File/Model/FileTable.php
+++ b/module/File/src/File/Model/FileTable.php
@@ -1,5 +1,28 @@
 <?php
 
+/**
+ *
+ * bareos-webui - Bareos Web-Frontend
+ * 
+ * @link      https://github.com/bareos/bareos-webui for the canonical source repository
+ * @copyright Copyright (c) 2013-2014 dass-IT GmbH (http://www.dass-it.de/)
+ * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 namespace File\Model;
 
 use Zend\Db\ResultSet\ResultSet;
@@ -7,22 +30,40 @@ use Zend\Db\TableGateway\TableGateway;
 use Zend\Db\Sql\Select;
 use Zend\Paginator\Adapter\DbSelect;
 use Zend\Paginator\Paginator;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Bareos\Db\Sql\BareosSqlCompatHelper;
 
-class FileTable
+class FileTable implements ServiceLocatorAwareInterface
 {
 
 	protected $tableGateway;
+	protected $serviceLocator;
 
 	public function __construct(TableGateway $tableGateway)
 	{
 		$this->tableGateway = $tableGateway;
 	}
 
+	public function setServiceLocator(ServiceLocatorInterface $serviceLocator) {
+                $this->serviceLocator = $serviceLocator;
+        }
+
+        public function getServiceLocator() {
+                return $this->serviceLocator;
+        }
+
+        public function getDbDriverConfig() {
+                $config = $this->getServiceLocator()->get('Config');
+                return $config['db']['driver'];
+        }
+
 	public function fetchAll($paginated=false) 
 	{
 		if($paginated) {
-			$select = new Select('file');
-			$select->order('fileid DESC');
+			$bsqlch = new BareosSqlCompatHelper($this->getDbDriverConfig());
+			$select = new Select($bsqlch->strdbcompat("File"));
+			$select->order($bsqlch->strdbcompat("FileId") . " DESC");
 			$resultSetPrototype = new ResultSet();
 			$resultSetPrototype->setArrayObjectPrototype(new File());
 			$paginatorAdapter = new DbSelect(
@@ -40,7 +81,8 @@ class FileTable
 	public function getFile($id)
 	{
 		$id = (int) $id;
-		$rowset = $this->tableGateway->select(array('fileid' => $id));
+		$bsqlch = new BareosSqlCompatHelper($this->getDbDriverConfig());
+		$rowset = $this->tableGateway->select(array($bsqlch->strdbcompat("FileId") => $id));
 		$row = $rowset->current();
 		if(!$row) {
 			throw new \Exception("Could not find row $id");
@@ -53,9 +95,14 @@ class FileTable
 		$paginated = true;
 		$jobid = (int) $id;
 		if($paginated) {
+			$bsqlch = new BareosSqlCompatHelper($this->getDbDriverConfig());
 			$select = new Select();
-			$select->from('file')->join('filename', 'file.filenameid = filename.filenameid');
-			$select->where('file.jobid = ' . $jobid);
+			$select->from($bsqlch->strdbcompat("File"));
+			$select->join(
+				$bsqlch->strdbcompat("Filename"), 
+				$bsqlch->strdbcompat("File.FilenameId = Filename.FilenameId")
+			);
+			$select->where($bsqlch->strdbcompat("File.JobId") .  " = '" . $jobid . "'");
 			$resultSetPrototype = new ResultSet();
 			$resultSetPrototype->setArrayObjectPrototype(new File());
 			$paginatorAdapter = new DbSelect(
@@ -72,8 +119,9 @@ class FileTable
 
 	public function getFileNum()
 	{
+		$bsqlch = new BareosSqlCompatHelper($this->getDbDriverConfig());
 		$select = new Select();
-		$select->from('file');
+		$select->from($bsqlch->strdbcompat("File"));
 		$resultSetPrototype = new ResultSet();
 		$resultSetPrototype->setArrayObjectPrototype(new File());
 		$rowset = new DbSelect(

--- a/module/Fileset/Module.php
+++ b/module/Fileset/Module.php
@@ -6,6 +6,7 @@ use Fileset\Model\Fileset;
 use Fileset\Model\FilesetTable;
 use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\TableGateway\TableGateway;
+use Bareos\Db\Sql\BareosSqlCompatHelper;
 
 class Module
 {
@@ -42,7 +43,9 @@ class Module
 					$dbAdapter = $sm->get('Zend\Db\Adapter\Adapter');
 					$resultSetPrototype = new ResultSet();
 					$resultSetPrototype->setArrayObjectPrototype(new Fileset());
-					return new TableGateway('fileset', $dbAdapter, null, $resultSetPrototype);
+					$config = $sm->get('Config');
+					$bsqlch = new BareosSqlCompatHelper($config['db']['driver']);
+					return new TableGateway($bsqlch->strdbcompat("FileSet"), $dbAdapter, null, $resultSetPrototype);
 				},
 			),
 		);

--- a/module/Fileset/src/Fileset/Model/Fileset.php
+++ b/module/Fileset/src/Fileset/Model/Fileset.php
@@ -35,6 +35,8 @@ class Fileset
 
 	public function exchangeArray($data)
 	{
+		$data = array_change_key_case($data, CASE_LOWER);		
+
 		$this->filesetid = (!empty($data['filesetid'])) ? $data['filesetid'] : null;
 		$this->fileset = (!empty($data['fileset'])) ? $data['fileset'] : null;
 		$this->md5 = (!empty($data['md5'])) ? $data['md5'] : null;

--- a/module/Job/Module.php
+++ b/module/Job/Module.php
@@ -6,6 +6,7 @@ use Job\Model\Job;
 use Job\Model\JobTable;
 use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\TableGateway\TableGateway;
+use Bareos\Db\Sql\BareosSqlCompatHelper;
 
 class Module 
 {
@@ -23,7 +24,9 @@ class Module
 					$dbAdapter = $sm->get('Zend\Db\Adapter\Adapter');
 					$resultSetPrototype = new ResultSet();
 					$resultSetPrototype->setArrayObjectPrototype(new Job());
-					return new TableGateway('job', $dbAdapter, null, $resultSetPrototype);
+					$config = $sm->get('Config');
+					$bsqlch = new BareosSqlCompatHelper($config['db']['driver']);
+					return new TableGateway($bsqlch->strdbcompat("Job"), $dbAdapter, null, $resultSetPrototype);
 				},
 			),
 		);

--- a/module/Job/src/Job/Controller/JobController.php
+++ b/module/Job/src/Job/Controller/JobController.php
@@ -147,7 +147,8 @@ class JobController extends AbstractActionController
 
 	public function getJobTable()
        	{
-		if(!$this->jobTable) {
+		if(!$this->jobTable) 
+		{
 			$sm = $this->getServiceLocator();
 			$this->jobTable = $sm->get('Job\Model\JobTable');
 		}

--- a/module/Job/src/Job/Model/Job.php
+++ b/module/Job/src/Job/Model/Job.php
@@ -59,6 +59,8 @@ class Job
 	
 	public function exchangeArray($data) 
 	{
+		$data = array_change_key_case($data, CASE_LOWER);
+
 		$this->jobid = (!empty($data['jobid'])) ? $data['jobid'] : null;
 		$this->job = (!empty($data['job'])) ? $data['job'] : null;
 		$this->jobname = (!empty($data['name'])) ? $data['name'] : null;

--- a/module/Log/Module.php
+++ b/module/Log/Module.php
@@ -6,6 +6,7 @@ use Log\Model\Log;
 use Log\Model\LogTable;
 use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\TableGateway\TableGateway;
+use Bareos\Db\Sql\BareosSqlCompatHelper;
 
 class Module 
 {
@@ -23,7 +24,9 @@ class Module
 					$dbAdapter = $sm->get('Zend\Db\Adapter\Adapter');
 					$resultSetPrototype = new ResultSet();
 					$resultSetPrototype->setArrayObjectPrototype(new Log());
-					return new TableGateway('log', $dbAdapter, null, $resultSetPrototype);
+					$config = $sm->get('Config');
+					$bsqlch = new BareosSqlCompatHelper($config['db']['driver']);
+					return new TableGateway($bsqlch->strdbcompat("Log"), $dbAdapter, null, $resultSetPrototype);
 				},
 			),
 		);

--- a/module/Log/src/Log/Model/Log.php
+++ b/module/Log/src/Log/Model/Log.php
@@ -12,6 +12,8 @@ class Log
 
 	public function exchangeArray($data) 
 	{
+		$data = array_change_key_case($data, CASE_LOWER);
+
 		$this->logid = (!empty($data['logid'])) ? $data['logid'] : null;
 		$this->jobid = (!empty($data['jobid'])) ? $data['jobid'] : null;
 		$this->time = (!empty($data['time'])) ? $data['time'] : null;

--- a/module/Media/Module.php
+++ b/module/Media/Module.php
@@ -6,6 +6,7 @@ use Media\Model\Media;
 use Media\Model\MediaTable;
 use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\TableGateway\TableGateway;
+use Bareos\Db\Sql\BareosSqlCompatHelper;
 
 class Module
 {
@@ -42,7 +43,9 @@ class Module
 					$dbAdapter = $sm->get('Zend\Db\Adapter\Adapter');
 					$resultSetPrototype = new ResultSet();
 					$resultSetPrototype->setArrayObjectPrototype(new Media());
-					return new TableGateway('media', $dbAdapter, null, $resultSetPrototype);
+					$config = $sm->get('Config');
+					$bsqlch = new BareosSqlCompatHelper($config['db']['driver']);
+					return new TableGateway($bsqlch->strdbcompat("Media"), $dbAdapter, null, $resultSetPrototype);
 				},
 			),
 		);

--- a/module/Media/src/Media/Model/Media.php
+++ b/module/Media/src/Media/Model/Media.php
@@ -73,6 +73,8 @@ class Media
 
 	public function exchangeArray($data)
 	{
+		$data = array_change_key_case($data, CASE_LOWER);
+
 		$this->mediaid = (!empty($data['mediaid'])) ? $data['mediaid'] : null;
 		$this->volumename = (!empty($data['volumename'])) ? $data['volumename'] : null;
 		$this->slot = (!empty($data['slot'])) ? $data['slot'] : null;

--- a/module/Media/src/Media/Model/MediaTable.php
+++ b/module/Media/src/Media/Model/MediaTable.php
@@ -31,22 +31,40 @@ use Zend\Db\Sql\Select;
 use Zend\Db\Sql\Sql;
 use Zend\Paginator\Adapter\DbSelect;
 use Zend\Paginator\Paginator;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Bareos\Db\Sql\BareosSqlCompatHelper;
 
-class MediaTable
+class MediaTable implements ServiceLocatorAwareInterface
 {
 
 	protected $tableGateway;
+	protected $serviceLocator;
 
 	public function __construct(TableGateway $tableGateway)
 	{
 		$this->tableGateway = $tableGateway;
 	}
 
+	public function setServiceLocator(ServiceLocatorInterface $serviceLocator) {
+                $this->serviceLocator = $serviceLocator;
+        }
+
+        public function getServiceLocator() {
+                return $this->serviceLocator;
+        }
+
+        public function getDbDriverConfig() {
+                $config = $this->getServiceLocator()->get('Config');
+                return $config['db']['driver'];
+        }
+
 	public function fetchAll($paginated=false) 
 	{
 		if($paginated) {
-			$select = new Select('media');
-			$select->order('mediaid ASC');
+			$bsqlch = new BareosSqlCompatHelper($this->getDbDriverConfig());
+			$select = new Select($bsqlch->strdbcompat("Media"));
+			$select->order($bsqlch->strdbcompat("MediaId") . " ASC");
 			$resultSetPrototype = new ResultSet();
 			$resultSetPrototype->setArrayObjectPrototype(new Media());
 			$paginatorAdapter = new DbSelect(
@@ -65,9 +83,10 @@ class MediaTable
 	{
 		$mediaid = (int) $id;
 		
+		$bsqlch = new BareosSqlCompatHelper($this->getDbDriverConfig());
 		$select = new Select();
-		$select->from('media');
-		$select->where('mediaid = ' . $mediaid);
+		$select->from($bsqlch->strdbcompat("Media"));
+		$select->where($bsqlch->strdbcompat("MediaId") . " = " . $mediaid);
 		
 		$resultSet = $this->tableGateway->selectWith($select);
 		$row = $resultSet->current();
@@ -77,8 +96,10 @@ class MediaTable
 
 	public function getMediaNum()
 	{
+		$bsqlch = new BareosSqlCompatHelper($this->getDbDriverConfig());
 		$select = new Select();
-		$select->from('media');
+		$select->from($bsqlch->strdbcompat("Media"));
+
 		$resultSetPrototype = new ResultSet();
 		$resultSetPrototype->setArrayObjectPrototype(new Media());
 		$rowset = new DbSelect(
@@ -87,6 +108,7 @@ class MediaTable
 			$resultSetPrototype
 		);
 		$num = $rowset->count();		  
+
 		return $num;
 	}
 	
@@ -94,10 +116,11 @@ class MediaTable
 	{
 		$poolid = (int) $id;
 		
+		$bsqlch = new BareosSqlCompatHelper($this->getDbDriverConfig());
 		$select = new Select();
-		$select->from('media');
-		$select->where('poolid = ' . $poolid);
-		$select->order('mediaid ASC');
+		$select->from($bsqlch->strdbcompat("Media"));
+		$select->where($bsqlch->strdbcompat("PoolId") . " = " . $poolid);
+		$select->order($bsqlch->strdbcompat("MediaId") . " ASC");
 		
 		$resultSet = $this->tableGateway->selectWith($select);
 		

--- a/module/Pool/Module.php
+++ b/module/Pool/Module.php
@@ -6,6 +6,7 @@ use Pool\Model\Pool;
 use Pool\Model\PoolTable;
 use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\TableGateway\TableGateway;
+use Bareos\Db\Sql\BareosSqlCompatHelper;
 
 class Module
 {
@@ -42,7 +43,9 @@ class Module
 					$dbAdapter = $sm->get('Zend\Db\Adapter\Adapter');
 					$resultSetPrototype = new ResultSet();
 					$resultSetPrototype->setArrayObjectPrototype(new Pool());
-					return new TableGateway('pool', $dbAdapter, null, $resultSetPrototype);
+					$config = $sm->get('Config');
+					$bsqlch = new BareosSqlCompatHelper($config['db']['driver']);
+					return new TableGateway($bsqlch->strdbcompat("Pool"), $dbAdapter, null, $resultSetPrototype);
 				},
 			),
 		);

--- a/module/Pool/src/Pool/Model/Pool.php
+++ b/module/Pool/src/Pool/Model/Pool.php
@@ -56,6 +56,8 @@ class Pool
 
 	public function exchangeArray($data)
 	{
+		$data = array_change_key_case($data, CASE_LOWER);
+
 		$this->poolid = (!empty($data['poolid'])) ? $data['poolid'] : null;
 		$this->name = (!empty($data['name'])) ? $data['name'] : null;
 		$this->numvols = (!empty($data['numvols'])) ? $data['numvols'] : null;

--- a/module/Storage/Module.php
+++ b/module/Storage/Module.php
@@ -6,6 +6,7 @@ use Storage\Model\Storage;
 use Storage\Model\StorageTable;
 use Zend\Db\ResultSet\ResultSet;
 use Zend\Db\TableGateway\TableGateway;
+use Bareos\Db\Sql\BareosSqlCompatHelper;
 
 class Module
 {
@@ -42,7 +43,9 @@ class Module
 					$dbAdapter = $sm->get('Zend\Db\Adapter\Adapter');
 					$resultSetPrototype = new ResultSet();
 					$resultSetPrototype->setArrayObjectPrototype(new Storage());
-					return new TableGateway('storage', $dbAdapter, null, $resultSetPrototype);
+					$config = $sm->get('Config');
+					$bsqlch = new BareosSqlCompatHelper($config['db']['driver']);
+					return new TableGateway($bsqlch->strdbcompat("Storage"), $dbAdapter, null, $resultSetPrototype);
 				},
 			),
 		);

--- a/vendor/Bareos/library/Bareos/Db/Sql/BareosSqlCompatHelper.php
+++ b/vendor/Bareos/library/Bareos/Db/Sql/BareosSqlCompatHelper.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bareos\Db\Sql;
+
+class BareosSqlCompatHelper 
+{
+
+	protected $dbDriverConfig;
+
+	public function __construct($dbDriverConfig) 
+	{
+		$this->dbDriverConfig = $dbDriverConfig;
+	}
+
+	public function strdbcompat($str) 
+	{
+		// PostgreSQL
+                if($this->dbDriverConfig == "Pdo_Pgsql" || $this->dbDriverConfig == "Pgsql") {
+                        $str = strtolower($str);
+                }
+                // MySQL
+                if($this->dbDriverConfig == "Pdo_Mysql" || $this->dbDriverConfig == "Mysqli") {
+                        return $str;
+                }
+                return $str;
+	}
+
+}


### PR DESCRIPTION
Table- and column-names are now passed into the SelectObject by a helper function, which
converts the string to lower-case e.g. for PostgreSQL or leaves it camel-case for MySQL,
so we don't need to repeat most of the code for different databases, as identifiers might
be different depending on which database you use. This is a workaround for an inconsistence
in the Bareos installation scripts relating the creation of needed database tables for
the catalogue. The helper function strdbcompat() might also be extended in future for Oracle
databases, where identifiers are handled upper-case by default and possible other databases.
