### PR TITLE
Fix

### DIFF
--- a/install/sudoers.d/bareos-webui-bconsole
+++ b/install/sudoers.d/bareos-webui-bconsole
@@ -1,4 +1,4 @@
 # allow apache to run bconsole. required for bareos-webui
-Cmnd_Alias BCONSOLE = /usr/sbin/bconsole -n -c /etc/bareos/bconsole.conf, /usr/sbin/bconsole -n -c /etc/bareos/webui/bconsole.conf, /usr/sbin/bconsole
-Defaults!BCONSOLE !requiretty
-wwwrun,www-data,apache ALL=(root) NOPASSWD: BCONSOLE
+Cmnd_Alias BCON = /usr/sbin/bconsole -n -c /etc/bareos/bconsole.conf, /usr/sbin/bconsole -n -c /etc/bareos/webui/bconsole.conf, /usr/sbin/bconsole
+Defaults!BCON !requiretty
+wwwrun,www-data,apache ALL=(root) NOPASSWD: BCON


### PR DESCRIPTION
Solves a variable collision, if webacula and bareos-webui are both installed.

Fixes #336: sudoers configuration collision between bareos-webui and webacula from repo
