### PR TITLE
add simple catalog handling

### DIFF
--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -134,6 +134,13 @@ function read_dir_config($config, $file)
             $arr[key($config)]['allowed_cns'] = "";
          }
 
+         if(array_key_exists('catalog', $instance) && isset($instance['catalog'])) {
+            $arr[key($config)]['catalog'] = $instance['catalog'];
+         }
+         else {
+            $arr[key($config)]['catalog'] = "MyCatalog";
+         }
+
       }
 
       next($config);

--- a/vendor/Bareos/library/Bareos/BSock/BareosBSock.php
+++ b/vendor/Bareos/library/Bareos/BSock/BareosBSock.php
@@ -78,6 +78,7 @@ class BareosBSock implements BareosBSockInterface
       'cert_file' => null,
       'cert_file_passphrase' => null,
       'allowed_cns' => null,
+      'catalog' => null,
    );
 
    private $socket = null;
@@ -870,7 +871,7 @@ class BareosBSock implements BareosBSockInterface
             break;
       }
 
-      if(self::send("use")) {
+      if(self::send("use catalog=" . $this->config['catalog'])) {
          $debug = self::receive_message();
       }
 


### PR DESCRIPTION
This pull request is for adding a simple catalog handling option.

Directors and corresponding catalogs can be defined in /etc/bareos-webui/directors.ini.

For example catalogs 1,2,3 on the localhost director:
```
[localhost catalog 1]
diraddress = "localhost"
catalog = "1"
[localhost catalog 2]
diraddress = "localhost"
catalog = "2"
[localhost catalog 3]
diraddress = "localhost"
catalog = "3"
```
On login you can choose between the different defined combinations of director and catalog.

If no catalog is defined, "MyCatalog" will be used.