### PR TITLE
Update README-INSTALL-FROM-SOURCE.md

### DIFF
--- a/doc/README-INSTALL-FROM-SOURCE.md
+++ b/doc/README-INSTALL-FROM-SOURCE.md
@@ -492,6 +492,13 @@ server {
                 # With php5-fpm:
 
                 fastcgi_pass unix:/var/run/php5-fpm.sock;
+                
+                
+                # Set APPLICATION_ENV to either 'production' or 'development'
+
+                fastcgi_param APPLICATION_ENV production;
+                
+                # fastcgi_param APPLICATION_ENV development;
 
         }
 


### PR DESCRIPTION
Added missing *APPLICATION_ENV* param in NGinx configuration.

This will prevent following error in NGinx access.log (which in turn prevents Bareos-WebUI to run):

...FastCGI sent in stderr: "PHP message: PHP Notice:  Undefined index: APPLICATION_ENV...