### PR TITLE
Update RestoreModel.php

### DIFF
--- a/module/Restore/src/Restore/Model/RestoreModel.php
+++ b/module/Restore/src/Restore/Model/RestoreModel.php
@@ -91,14 +91,14 @@ class RestoreModel
    public function getJobIds(&$bsock=null, $jobid=null, $mergefilesets=0, $mergejobs=0)
    {
       if(isset($bsock)) {
-         if($mergefilesets == 0 && $mergejobs == 0) {
+         if($mergefilesets == 1 && $mergejobs == 1) {
+            return $jobid;
+         }
+         if($mergefilesets == 0) {
             $cmd = '.bvfs_get_jobids jobid='.$jobid.' all';
          }
-         elseif($mergefilesets == 1 && $mergejobs == 0) {
+         else {
             $cmd = '.bvfs_get_jobids jobid='.$jobid.'';
-         }
-         elseif($mergefilesets == 1 && $mergejobs == 1) {
-            return $jobid;
          }
          $result = $bsock->send_command($cmd, 2, null);
          $jobids = \Zend\Json\Json::decode($result, \Zend\Json\Json::TYPE_ARRAY);


### PR DESCRIPTION
There's a situation where if $mergefilesets==0 and $mergejobs==1, the $cmd variable isn't set and code is executed, leading into an error trying to get jobids. The user shouldn't be able to select this situation, but I have tried this, and it can happen.
I'm proposing a change in the if-structure so that $cmd is always correctly set.